### PR TITLE
Claim invitation on registration

### DIFF
--- a/app/controllers/api/v1/invitations_controller.rb
+++ b/app/controllers/api/v1/invitations_controller.rb
@@ -15,11 +15,22 @@ class Api::V1::InvitationsController < Api::V1::ApplicationController
   # Handles invitation creation
   def create
     invitation = current_account.invitations.build(invitation_params)
+    user = User.find_by(:email => invitation_params[:email])
 
-    if invitation.save
-      render :json => invitation
+    if user
+      if invitable = invitation.invitable
+        invitation.membership = invitable.memberships.create(
+          :creator => current_account, :user => user)
+        render :json => invitation
+      else
+        render :json => { :errors => [_('Email is registered.')] }
+      end
     else
-      render :json => { :errors => invitation.errors.messages }
+      if invitation.save
+        render :json => invitation
+      else
+        render :json => { :errors => invitation.errors.messages }
+      end
     end
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -16,8 +16,25 @@ class SessionsController < ApplicationController
     redirect_to root_path
   end
 
+  # Callback to be called after someone signs in
+  def after_successful_sign_in
+    invite = current_account.claim_invitation
+    if invite
+      invitable = invite.invitable
+      invitable_name = invitable.class.name.downcase
+      anchor = '/%s/%d' % [invitable_name.pluralize, invitable.id]
+
+      flash[:success] = _('%s invited you to collaborate on %s %s.') % [
+        invite.user.nicename, invitable.title, invitable_name ]
+
+      redirect_to root_path(:anchor => anchor)
+    else
+      super
+    end
+  end
+
   # Returns location to redirect after signing in
   def after_successful_sign_in_url
-    profile_path(current_account)
+    root_path
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,6 +2,9 @@
 class SessionsController < ApplicationController
   include EasyAuth::Controllers::Sessions
 
+  # Skip authentication check to make sure we can log out
+  skip_before_filter :require_confirmation, :only => [:destroy]
+
   # Show available authentication options
   def index
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -17,6 +17,14 @@ class UserMailer < ActionMailer::Base
       project.title, Doers::Config.app_name])
   end
 
+  # Sends a notice to the invitation creator
+  def invitation_claimed(invitation, user)
+    @invitation = invitation
+    @user = user
+    mail(:to => invitation.user.email, :subject => _('%s joined %s.') % [
+      @user.nicename, Doers::Config.app_name])
+  end
+
   # Sends an invitation for a project/board or just to join
   def invite(invitation)
     @invitable = invitation.invitable

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -33,6 +33,21 @@ class Invitation < ActiveRecord::Base
   after_commit :generate_activity, :on => [:create]
   after_commit :email_invite, :on => [:create]
 
+  # Sugaring to check if invitation is claimed
+  def claimer
+    User.find_by(:email => self.email)
+  end
+
+  # Sugaring to help validation of an invitable project
+  def for_project?
+    self.invitable.is_a?(Project)
+  end
+
+  # Sugaring to help validation of an invitable board
+  def for_board?
+    self.invitable.is_a?(Board)
+  end
+
   private
 
     # Emails the invitation
@@ -48,15 +63,5 @@ class Invitation < ActiveRecord::Base
     # Board ids user branched/authored
     def user_board_ids
       self.user.branched_board_ids + self.user.authored_board_ids + [nil]
-    end
-
-    # Sugaring to help validation of an invitable project
-    def for_project?
-      self.invitable.is_a?(Project)
-    end
-
-    # Sugaring to help validation of an invitable board
-    def for_board?
-      self.invitable.is_a?(Board)
     end
 end

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -8,6 +8,7 @@ class Membership < ActiveRecord::Base
   belongs_to :user
   belongs_to :board
   belongs_to :project
+  has_one :invitation
 
   # Validations
   validates_presence_of :user, :creator

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,15 +23,19 @@ class User < ActiveRecord::Base
   has_many :assets
   has_many :images, :class_name => Asset::Image
   has_many :activities
-  has_many :memberships, :dependent => :destroy
+  has_many(:created_memberships, :dependent => :destroy,
+           :foreign_key => :creator_id, :class_name => Membership)
+  has_many(:accepted_memberships, :dependent => :destroy,
+           :class_name => Membership)
   has_many :invitations, :dependent => :destroy
 
   has_many :branched_boards, :class_name => Board
   has_many :authored_boards, :foreign_key => :author_id, :class_name => Board
-  has_many :shared_boards, :through => :memberships, :source => :board
+  has_many :shared_boards, :through => :accepted_memberships, :source => :board
 
   has_many :created_projects, :class_name => Project, :dependent => :destroy
-  has_many :shared_projects, :through => :memberships, :source => :project
+  has_many(
+    :shared_projects, :through => :accepted_memberships, :source => :project)
 
   # Validations
   validates :email, :uniqueness => true, :presence => true
@@ -50,6 +54,11 @@ class User < ActiveRecord::Base
   # All user boards
   def boards
     Board.where(:id => (shared_board_ids + branched_board_ids))
+  end
+
+  # All user memberships
+  def memberships
+    Membership.where(:id => (created_membership_ids + accepted_membership_ids))
   end
 
   # Helper to generate the user name

--- a/app/serializers/invitation_serializer.rb
+++ b/app/serializers/invitation_serializer.rb
@@ -3,10 +3,9 @@ class InvitationSerializer < ActiveModel::Serializer
   include GravatarHelper
 
   attributes :id, :email, :project_id, :board_id, :membership_type
-  attributes :avatar_url
+  attributes :avatar_url, :membership_id
 
   has_one :user, :embed => :id
-  has_one :membership, :embed => :id
 
   # Handles serialization of membership type
   def membership_type

--- a/app/views/user_mailer/invitation_claimed.text.haml
+++ b/app/views/user_mailer/invitation_claimed.text.haml
@@ -1,0 +1,19 @@
+= _('Hello again %s.') % @invitation.user.nicename
+\
+\
+- if invitable = @invitation.invitable
+  - if @invitation.for_project?
+    = _('%s joined %s project on %s.') % [@user.nicename, invitable.title, Doers::Config.app_name]
+  - else
+    = _('%s joined %s board on %s.') % [@user.nicename, invitable.title, Doers::Config.app_name]
+- else
+  = _('%s joined %s.') % [@user.nicename, Doers::Config.app_name]
+
+\
+= _('To catch up, visit %s') % root_url
+\
+= _('Thank you.')
+\
+\
+= _('Your %s team.') % Doers::Config.app_name
+= Doers::Config.app_id

--- a/spec/controllers/api/v1/memberships_controller_spec.rb
+++ b/spec/controllers/api/v1/memberships_controller_spec.rb
@@ -15,6 +15,14 @@ describe Api::V1::MembershipsController do
 
     its(:memberships) { should be_empty }
 
+    context 'for created memberships' do
+      let(:memb_ids) do
+        3.times.collect{ Fabricate(:project_membership, :creator => user).id }
+      end
+
+      its('memberships.size') { should eq(user.memberships.count) }
+    end
+
     context 'for owned memberships' do
       let(:memb_ids) do
         3.times.collect{ Fabricate(:project_membership, :user => user).id }

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -2,17 +2,10 @@ require 'spec_helper'
 
 describe SessionsController do
 
-  describe 'private methods' do
-    let(:user_attr) { Fabricate.build(:user, :id => 1) }
-    before do
-      controller.should_receive(:current_account).and_return(user_attr)
-    end
-
+  describe '#after_successful_sign_in_url' do
     it 'returns after redirect location' do
-      controller.send(:after_successful_sign_in_url).should eq(
-        profile_path(user_attr))
+      controller.send(:after_successful_sign_in_url).should eq(root_path)
     end
-
   end
 
   describe '#index' do
@@ -42,7 +35,7 @@ describe SessionsController do
         {:provider => :angel_list, :identity => :oauth2, :code => 'DUMMY_CODE'}
       end
 
-      it { should redirect_to(profile_path(User.first)) }
+      it { should redirect_to(root_path) }
       its('flash.keys') { should include(:notice) }
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -18,6 +18,7 @@ describe SessionsController do
 
   describe '#create' do
     let(:params) {  }
+    let!(:invitation) { }
     before { get(:create, params) }
 
     context 'for denied authentication' do
@@ -37,6 +38,18 @@ describe SessionsController do
 
       it { should redirect_to(root_path) }
       its('flash.keys') { should include(:notice) }
+
+      context '#after_successful_sign_in' do
+        let(:invitation) {
+          Fabricate(:board_invitation, :email => 'doer@geekcelerator.com') }
+        let(:invitable) { invitation.invitable }
+
+        it 'redirects to shared project' do
+          anchor = '/%s/%d' % [invitable.class.name.downcase.pluralize,invitable.id]
+          should redirect_to(root_path(:anchor => anchor))
+        end
+      end
+
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -35,6 +35,19 @@ describe UserMailer do
     its(:to) { should include(user.email) }
   end
 
+  context '#Invitation_claimed' do
+    let(:invitation) { Fabricate(:project_invitee) }
+    let(:user) { User.find_by(:email => invitation.email) }
+
+    before { UserMailer.invitation_claimed(invitation, user).deliver }
+
+    it_should_behave_like 'an email from us'
+    its('body.encoded') { should match(invitation.user.nicename) }
+    its('body.encoded') { should match(user.nicename) }
+    its('body.encoded') { should match(invitation.invitable.title) }
+    its(:to) { should include(invitation.user.email) }
+  end
+
   context '#invite' do
     shared_examples 'an invitation from us' do
       its(:to) { should include(invitation.email) }

--- a/spec/models/invitation_spec.rb
+++ b/spec/models/invitation_spec.rb
@@ -32,7 +32,17 @@ describe Invitation do
   end
 
   context 'instance' do
-    let(:invitation) { Fabricate(:invitation) }
+    subject(:invitation) { Fabricate(:invitation) }
+
+    context '#claimer' do
+      its(:claimer) { should be_blank }
+
+      context 'when #email is registered' do
+        let(:invitation) { Fabricate(:project_invitee) }
+
+        its(:claimer) { should eq(invitation.membership.user) }
+      end
+    end
 
     context 'sends an email on creation', :use_truncation do
       before { UserMailer.should_receive(:invite) }

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -5,6 +5,7 @@ describe Membership do
   it { should belong_to(:creator) }
   it { should belong_to(:project) }
   it { should belong_to(:board) }
+  it { should have_one(:invitation) }
   it { should validate_presence_of(:creator) }
   it { should validate_presence_of(:user) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,19 +1,18 @@
 require 'spec_helper'
 
 describe User do
-  let(:user) { Fabricate(:user) }
-
   it { should have_many(:created_projects).dependent(:destroy) }
-  it { should have_many(:shared_projects).through(:memberships) }
+  it { should have_many(:shared_projects).through(:accepted_memberships) }
   it { should have_many(:branched_boards).dependent('') }
   it { should have_many(:authored_boards).dependent('') }
-  it { should have_many(:shared_boards).through(:memberships) }
+  it { should have_many(:shared_boards).through(:accepted_memberships) }
   it { should have_many(:cards).dependent('') }
   it { should have_many(:comments) }
   it { should have_many(:assets) }
   it { should have_many(:images).dependent('') }
   it { should have_many(:activities).dependent('') }
-  it { should have_many(:memberships).dependent(:destroy) }
+  it { should have_many(:created_memberships).dependent(:destroy) }
+  it { should have_many(:accepted_memberships).dependent(:destroy) }
   it { should have_many(:invitations).dependent(:destroy) }
 
   it { should validate_presence_of(:email) }
@@ -27,7 +26,7 @@ describe User do
   end
 
   context 'instance' do
-    subject { user }
+    subject(:user) { Fabricate(:user) }
 
     it { should be_valid }
     its('identities.first.uid') { should eq(user.email) }
@@ -51,6 +50,12 @@ describe User do
       let(:board) { Fabricate(:board, :user => user) }
 
       its(:boards) { should include(board) }
+    end
+
+    context '#memberships' do
+      let(:membership) { Fabricate(:project_membership, :user => user) }
+
+      its(:memberships) { should include(membership) }
     end
 
     context '#newsletter_allowed?' do


### PR DESCRIPTION
There are a couple of features introduced here:
- `User#memberships` now includes both, the accepted and created memberships for an user
- Sessions controller now tries to claim any invitations exist upon authentication. Didn't move this to the model `after_create` callback since we need to have access to the invitation `invitable` attribute in order to redirect to its screen
- Invitations controller upon creation of a new entry, if the email is already registered, will try to create the membership, or notify with an error that email is already registered.
- Inivtation creator now gets an email when an user claimed his invitation

@stefangugurel please review and merge this.
