### PR TITLE
Comments on cards

### DIFF
--- a/app/assets/javascripts/models/activity.js.coffee
+++ b/app/assets/javascripts/models/activity.js.coffee
@@ -5,6 +5,7 @@ Doers.Activity = DS.Model.extend
   user: DS.belongsTo('Doers.User', readOnly: true, inverse: 'activities')
   project: DS.belongsTo('Doers.User', readOnly: true, inverse: 'activities')
   board: DS.belongsTo('Doers.User', readOnly: true, inverse: 'activities')
+  comment: DS.belongsTo('Doers.Comment', readOnly: true)
   # This one can go pretty crazy since it can represent:
   #   user, card, asset or other objects
   #   so we better load it when we really need it

--- a/app/assets/javascripts/models/card.js.coffee
+++ b/app/assets/javascripts/models/card.js.coffee
@@ -15,6 +15,7 @@ Doers.Card = DS.Model.extend
   board: DS.belongsTo('Doers.Board')
   user: DS.belongsTo('Doers.User', readOnly: true)
   activities: DS.hasMany('Doers.Activity', readOnly: true, inverse: 'trackable', polymorphic: true)
+  comments: DS.hasMany('Doers.Comment', readOnly: true, inverse: 'card')
 
   updatedAt: DS.attr('date', readOnly: true)
 

--- a/app/assets/javascripts/models/comment.js.coffee
+++ b/app/assets/javascripts/models/comment.js.coffee
@@ -1,0 +1,14 @@
+Doers.Comment = DS.Model.extend
+  content: DS.attr('string')
+  externalAuthorName: DS.attr('string', readOnly: true)
+  updatedAt: DS.attr('date')
+
+  user: DS.belongsTo('Doers.User', readOnly: true, inverse: 'comments')
+  project: DS.belongsTo('Doers.Project', readOnly: true, inverse: 'comments')
+  board: DS.belongsTo('Doers.Board', readOnly: true, inverse: 'comments')
+  card: DS.belongsTo('Doers.Card', readOnly: true, inverse: 'comments')
+  parentComment: DS.belongsTo('Doers.Comment', readOnly: true, inverse: 'comments')
+  comments: DS.hasMany('Doers.Comment', readOnly: true, inverse: 'parentComment')
+
+  commentableId: DS.attr('number')
+  commentableType: DS.attr('string', defaultValue: 'Card')

--- a/app/assets/javascripts/models/comment.js.coffee
+++ b/app/assets/javascripts/models/comment.js.coffee
@@ -1,13 +1,13 @@
 Doers.Comment = DS.Model.extend
   content: DS.attr('string')
-  externalAuthorName: DS.attr('string', readOnly: true)
+  parentComment: DS.belongsTo('Doers.Comment', inverse: 'comments')
   updatedAt: DS.attr('date')
 
   user: DS.belongsTo('Doers.User', readOnly: true, inverse: 'comments')
-  project: DS.belongsTo('Doers.Project', readOnly: true, inverse: 'comments')
-  board: DS.belongsTo('Doers.Board', readOnly: true, inverse: 'comments')
+  project: DS.belongsTo('Doers.Project', inverse: 'comments')
+  board: DS.belongsTo('Doers.Board', inverse: 'comments')
   card: DS.belongsTo('Doers.Card', readOnly: true, inverse: 'comments')
-  parentComment: DS.belongsTo('Doers.Comment', readOnly: true, inverse: 'comments')
+  externalAuthorName: DS.attr('string', readOnly: true)
   comments: DS.hasMany('Doers.Comment', readOnly: true, inverse: 'parentComment')
 
   commentableId: DS.attr('number')

--- a/app/controllers/api/v1/comments_controller.rb
+++ b/app/controllers/api/v1/comments_controller.rb
@@ -1,0 +1,57 @@
+# API (v1) comments controller class
+class Api::V1::CommentsController < Api::V1::ApplicationController
+  # Lists available comments
+  def index
+    comments = Comment.where(:id => params[:ids])
+    current_account.can?(:read, comments)
+    render :json => comments
+  end
+
+  # Shows a comment
+  def show
+    comment = Comment.find(params[:id])
+    current_account.can?(:read, comment)
+    render :json => comment
+  end
+
+  # Handles comment creation
+  def create
+    commentable_type = comment_params[:commentable_type]
+    comment = current_account.comments.build
+    errors = nil
+
+    if (commentable_type == 'Card' or commentable_type.blank?)
+      comment.attributes = comment_params
+      commentable = (comment.commentable || comment.board || comment.project)
+      current_account.can?(:read, commentable)
+    else
+      errors = [_('Commentable not allowed.')]
+    end
+
+    if !errors and comment.save
+      render :json => comment
+    else
+      render :json => { :errors => errors || comment.errors.messages }
+    end
+  end
+
+  # Handles comment deletion
+  def destroy
+    comment = Comment.find_by(:id => params[:id])
+    can_destroy = current_account.can?(:write, comment, :raise_error => false)
+
+    if comment and can_destroy and comment.destroy
+      render :nothing => true, :status => 204
+    else
+      render :nothing => true, :status => 400
+    end
+  end
+
+  private
+
+    # Strong parameters for comment object
+    def comment_params
+      params.require(:comment).permit(:content, :project_id, :board_id,
+        :commentable_id, :commentable_type, :parent_comment_id)
+    end
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -2,7 +2,7 @@
 class Activity < ActiveRecord::Base
   # Some dynamic attributes
   store_accessor :data, :user_name, :project_title, :board_title
-  store_accessor :data, :trackable_title
+  store_accessor :data, :trackable_title, :comment_id
 
   # Relationships
   belongs_to :project

--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -17,6 +17,7 @@ class Card < ActiveRecord::Base
   belongs_to :board
   belongs_to :project
   has_many :activities, :as => :trackable
+  has_many :comments, :as => :commentable, :dependent => :destroy
 
   # Validations
   validates_presence_of :user, :board

--- a/app/models/concerns/activity/support.rb
+++ b/app/models/concerns/activity/support.rb
@@ -8,7 +8,7 @@ module Activity::Support
       slug = 'update'
       slug = 'create' if self.transaction_record_state(:new_record)
       slug = 'destroy' if destroyed?
-      [slug, self.class.name.underscore.split('_'), postfix].
+      [slug, self.class.name.underscore.split('_'), postfix].compact.
         flatten.join(' ').parameterize
     end
 
@@ -36,7 +36,7 @@ module Activity::Support
     # Activity generation hook
     def generate_activity(append_to_slug=nil)
       activity = self.activities.build(activity_params)
-      activity.slug = activity_slug(append_to_slug) unless append_to_slug.nil?
+      activity.slug = activity_slug(append_to_slug)
       activity.save!
     end
 end

--- a/app/models/concerns/user/authorization.rb
+++ b/app/models/concerns/user/authorization.rb
@@ -22,6 +22,8 @@ module User::Authorization
       !cards_to(action).where(:id => target).empty?
     when 'Activity'
       !activities_to(action).where(:id => target).empty?
+    when 'Comment'
+      !comments_to(action).where(:id => target).empty?
     when /Membership/
       # Just check if we are the creators or users of it
       target.creator_id == self.id or target.user_id == self.id
@@ -157,5 +159,34 @@ module User::Authorization
     end
 
     Activity.where(query)
+  end
+
+  # Available comments for user, `action` can be :read or :write
+  def comments_to(action)
+    table = Comment.arel_table
+
+    # User is the owner
+    query = table[:user_id].eq(self.id)
+
+    if action.to_sym != :write
+      query = query.or(
+        # User branched the board
+        table[:board_id].in(self.branched_board_ids).or(
+          # User created the board
+          table[:board_id].in(self.authored_board_ids)
+        ).or(
+          # Somebody shared its board
+          table[:board_id].in(self.shared_board_ids)
+        )
+      ).or(
+        # User project has it
+        table[:project_id].in(self.created_project_ids).or(
+          # Somebody shared the project
+          table[:project_id].in(self.shared_project_ids)
+        )
+      )
+    end
+
+    Comment.where(query)
   end
 end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -48,6 +48,11 @@ class Invitation < ActiveRecord::Base
     self.invitable.is_a?(Board)
   end
 
+  # Target to use when generating activities
+  def activity_title
+    self.email
+  end
+
   private
 
     # Emails the invitation

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -12,4 +12,9 @@ class Membership < ActiveRecord::Base
 
   # Validations
   validates_presence_of :user, :creator
+
+  # Target to use when generating activities
+  def activity_title
+    self.user.nicename
+  end
 end

--- a/app/serializers/activity_serializer.rb
+++ b/app/serializers/activity_serializer.rb
@@ -2,7 +2,7 @@
 class ActivitySerializer < ActiveModel::Serializer
   attributes :id, :slug, :updated_at, :last_update
   attributes :user_name, :project_title, :board_title, :trackable_title
-  attributes :trackable_id, :trackable_type
+  attributes :trackable_id, :trackable_type, :comment_id
 
   has_one :user, :embed => :id
   has_one :project, :embed => :id

--- a/app/serializers/card_serializer.rb
+++ b/app/serializers/card_serializer.rb
@@ -9,6 +9,7 @@ class CardSerializer < ActiveModel::Serializer
   has_one :project, :embed => :id
   has_one :board, :embed => :id
   has_many :activities, :embed => :id
+  has_many :comments, :embed => :id
 
   # Generates it out of the card type
   def type

--- a/app/serializers/comment_serializer.rb
+++ b/app/serializers/comment_serializer.rb
@@ -1,0 +1,16 @@
+# [Comment] model serializer
+class CommentSerializer < ActiveModel::Serializer
+  attributes :id, :content, :external_author_name, :updated_at
+  attributes :card_id
+
+  has_one :user, :embed => :id
+  has_one :project, :embed => :id
+  has_one :board, :embed => :id
+  has_one :parent_comment, :embed => :id
+  has_many :comments, :embed => :id
+
+  # Handles card id serialization based on polymorphic relationship
+  def card_id
+    object.commentable.id if object.commentable.is_a?(Card)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,7 @@ Doers::Application.routes.draw do
       resources(:activities, :except => [:create, :update])
       resources(:invitations, :except => [:update])
       resources(:memberships, :only => [:index, :show, :destroy])
+      resources(:comments, :except => [:update])
     end
   end
 

--- a/db/migrate/20130906105048_add_comtable_to_comments.rb
+++ b/db/migrate/20130906105048_add_comtable_to_comments.rb
@@ -1,0 +1,8 @@
+class AddComtableToComments < ActiveRecord::Migration
+  def change
+    add_column :comments, :commentable_id, :integer
+    add_column :comments, :commentable_type, :string
+
+    add_index :comments, [:commentable_id, :commentable_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20130902112423) do
+ActiveRecord::Schema.define(version: 20130906105048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,9 +108,12 @@ ActiveRecord::Schema.define(version: 20130902112423) do
     t.hstore   "data"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "commentable_id"
+    t.string   "commentable_type"
   end
 
   add_index "comments", ["board_id"], name: "index_comments_on_board_id", using: :btree
+  add_index "comments", ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
   add_index "comments", ["parent_comment_id"], name: "index_comments_on_parent_comment_id", using: :btree
   add_index "comments", ["project_id"], name: "index_comments_on_project_id", using: :btree
   add_index "comments", ["user_id"], name: "index_comments_on_user_id", using: :btree

--- a/db/seeds/development/boards.seeds.rb
+++ b/db/seeds/development/boards.seeds.rb
@@ -17,6 +17,15 @@ after 'development:projects' do
     persona.branch_for(user, project, {:title => persona.title} )
     problem.branch_for(user, project, {:title => problem.title} )
   end
+  # Add some comments
+  user.boards.each do |board|
+    board.cards.each do |card|
+      [0, 2, 4].sample.times do
+        Fabricate(:comment, :user => user, :project => board.project,
+          :board => board, :commentable => card)
+      end
+    end
+  end
 
   # Other project boards
   projects = Project.all - user.projects

--- a/spec/controllers/api/v1/activities_controller_spec.rb
+++ b/spec/controllers/api/v1/activities_controller_spec.rb
@@ -25,12 +25,13 @@ describe Api::V1::ActivitiesController, :use_truncation do
 
     subject(:api_activity) { json_to_ostruct(response.body, :activity) }
 
-    its('keys.size') { should eq(13) }
+    its('keys.size') { should eq(14) }
     its(:id) { should eq(activity.id) }
     its(:slug) { should eq(activity.slug) }
     its(:user_id) { should eq(user.id) }
     its(:project_id) { should be_nil }
     its(:board_id) { should be_nil }
+    its(:comment_id) { should be_nil }
     its(:trackable_id) { should eq(user.id) }
     its(:trackable_type) { should eq(user.class.name) }
     its(:user_name) { should eq(user.nicename) }

--- a/spec/controllers/api/v1/cards_controller_spec.rb
+++ b/spec/controllers/api/v1/cards_controller_spec.rb
@@ -63,9 +63,10 @@ describe Api::V1::CardsController do
       its(:project_id) { should eq(card.project.id) }
       its(:board_id) { should eq(card.board.id) }
       its('activity_ids.size') { should eq(card.activities.count) }
+      its('comment_ids.size') { should eq(card.comments.count) }
 
       context 'phrase card' do
-        its('keys.size') { should eq(14) }
+        its('keys.size') { should eq(15) }
         its(:content) { should eq(card.content) }
       end
 
@@ -73,7 +74,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/paragraph', :project => project, :board => board) }
 
-        its('keys.size') { should eq(14) }
+        its('keys.size') { should eq(15) }
         its(:content) { should eq(card.content) }
       end
 
@@ -81,7 +82,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/number', :project => project, :board => board) }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its(:number) { should eq(card.number) }
         its(:content) { should eq(card.content) }
       end
@@ -90,7 +91,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/timestamp', :project => project, :board => board) }
 
-        its('keys.size') { should eq(14) }
+        its('keys.size') { should eq(15) }
         its(:content) { should eq(card.content) }
       end
 
@@ -98,7 +99,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/interval', :project => project, :board => board) }
 
-        its('keys.size') { should eq(17) }
+        its('keys.size') { should eq(18) }
         its(:minimum) { should eq(card.minimum) }
         its(:maximum) { should eq(card.maximum) }
         its(:selected) { should eq(card.selected) }
@@ -108,7 +109,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/book', :project => project, :board => board) }
 
-        its('keys.size') { should eq(18) }
+        its('keys.size') { should eq(19) }
         its(:url) { should eq(card.url) }
         its(:book_title) { should eq(card.book_title) }
         its(:book_authors) { should eq(card.book_authors) }
@@ -119,7 +120,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/photo', :project => project, :board => board) }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its(:image_id) { should eq(card.image.id) }
       end
 
@@ -127,7 +128,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/video', :project => project, :board => board) }
 
-        its('keys.size') { should eq(17) }
+        its('keys.size') { should eq(18) }
         its(:image_id) { should eq(card.image.id) }
         its(:video_id) { should eq(card.video_id) }
         its(:provider) { should eq(card.provider) }
@@ -137,7 +138,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/map', :project => project, :board => board) }
 
-        its('keys.size') { should eq(16) }
+        its('keys.size') { should eq(17) }
         its(:latitude) { should eq(card.latitude.to_f) }
         its(:longitude) { should eq(card.longitude.to_f) }
         its(:content) { should eq(card.content) }
@@ -147,7 +148,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/link', :project => project, :board => board) }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its(:url) { should eq(card.url) }
         its(:content) { should eq(card.content) }
       end
@@ -156,7 +157,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/list', :project => project, :board => board) }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its('items.size') { should eq(card.reload.items.size) }
         its(:content) { should eq(card.content) }
 
@@ -209,7 +210,7 @@ describe Api::V1::CardsController do
 
       subject(:api_card) { json_to_ostruct(response.body, :card) }
 
-      its('keys.size') { should eq(14) }
+      its('keys.size') { should eq(15) }
       its(:id) { should_not be_blank }
       its(:title) { should eq(card_attrs[:title]) }
       its(:title_hint) { should eq(card_attrs[:title_hint]) }
@@ -266,7 +267,7 @@ describe Api::V1::CardsController do
         let(:card) {
           Fabricate('card/phrase', :project => project, :board => board)}
 
-        its('keys.size') { should eq(14) }
+        its('keys.size') { should eq(15) }
         its(:title) { should eq(card_attrs['title']) }
         its(:content) { should eq(Sanitize.clean(card_attrs['content'])) }
       end
@@ -276,7 +277,7 @@ describe Api::V1::CardsController do
           Fabricate('card/paragraph', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/paragraph') }
 
-        its('keys.size') { should eq(14) }
+        its('keys.size') { should eq(15) }
         its(:title) { should eq(card_attrs['title']) }
         its(:content) { should eq(Sanitize.clean(card_attrs['content'])) }
       end
@@ -286,7 +287,7 @@ describe Api::V1::CardsController do
           Fabricate('card/number', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/number') }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its(:title) { should eq(card_attrs['title']) }
         its(:number) { should eq(card_attrs['number']) }
         its(:content) { should eq(card_attrs['content']) }
@@ -297,7 +298,7 @@ describe Api::V1::CardsController do
           Fabricate('card/timestamp', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/timestamp') }
 
-        its('keys.size') { should eq(14) }
+        its('keys.size') { should eq(15) }
         its(:title) { should eq(card_attrs['title']) }
         its(:content) { should eq(card_attrs['content']) }
       end
@@ -307,7 +308,7 @@ describe Api::V1::CardsController do
           Fabricate('card/interval', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/interval') }
 
-        its('keys.size') { should eq(17) }
+        its('keys.size') { should eq(18) }
         its(:title) { should eq(card_attrs['title']) }
         its(:minimum) { should eq(card_attrs['minimum']) }
         its(:maximum) { should eq(card_attrs['maximum']) }
@@ -319,7 +320,7 @@ describe Api::V1::CardsController do
           Fabricate('card/photo', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/photo') }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its(:title) { should eq(card_attrs['title']) }
         its(:content) { should eq(Sanitize.clean(card_attrs['content'])) }
         its(:image_id) { should eq(card.image.id) }
@@ -330,7 +331,7 @@ describe Api::V1::CardsController do
           Fabricate('card/video', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/video') }
 
-        its('keys.size') { should eq(17) }
+        its('keys.size') { should eq(18) }
         its(:title) { should eq(card_attrs['title']) }
         its(:content) { should eq(Sanitize.clean(card_attrs['content'])) }
         its(:video_id) { should eq(card_attrs[:video_id]) }
@@ -343,7 +344,7 @@ describe Api::V1::CardsController do
           Fabricate('card/link', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/link') }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its(:title) { should eq(card_attrs['title']) }
         its(:url) { should eq(card_attrs['url']) }
         its(:content) { should eq(Sanitize.clean(card_attrs['content'])) }
@@ -354,7 +355,7 @@ describe Api::V1::CardsController do
           Fabricate('card/map', :project => project, :board => board)}
         let(:card_attrs) { Fabricate.attributes_for('card/map') }
 
-        its('keys.size') { should eq(16) }
+        its('keys.size') { should eq(17) }
         its(:title) { should eq(card_attrs['title']) }
         its(:content) { should eq(Sanitize.clean(card_attrs['content'])) }
         its(:latitude) { should eq(card_attrs['latitude']) }
@@ -366,7 +367,7 @@ describe Api::V1::CardsController do
           Fabricate('card/list', :project => project, :board => board) }
         let(:card_attrs) { Fabricate.attributes_for('card/list') }
 
-        its('keys.size') { should eq(15) }
+        its('keys.size') { should eq(16) }
         its('items.size') { should eq(card.reload.items.size) }
         its(:content) { should eq(card_attrs['content']) }
 

--- a/spec/controllers/api/v1/comments_controller_spec.rb
+++ b/spec/controllers/api/v1/comments_controller_spec.rb
@@ -1,0 +1,164 @@
+require 'spec_helper'
+
+describe Api::V1::CommentsController do
+  let(:user) { Fabricate(:user) }
+
+  before do
+    controller.stub(:current_account) { user }
+  end
+
+  describe '#index' do
+    let(:comment_ids) { [] }
+
+    context 'when no comments are queries' do
+      before { get(:index, :ids => comment_ids) }
+
+      subject(:api_comments) { json_to_ostruct(response.body) }
+
+      its(:comments) { should be_empty }
+    end
+
+    context 'for available comments' do
+      let(:comment_ids) do
+        3.times.collect{ Fabricate(:comment, :user => user).id }
+      end
+
+      before { get(:index, :ids => comment_ids) }
+      subject(:api_comments) { json_to_ostruct(response.body) }
+
+      its('comments.size') { should eq(user.comments.count) }
+    end
+
+    context 'for a not owned comments' do
+      let(:comment_ids) { [Fabricate(:comment).id] }
+
+      it 'raises 404' do
+        expect{ get(:index, :ids => comment_ids) }.to raise_error(
+          ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe '#show' do
+    let(:comment) { Fabricate(:comment) }
+    let(:comment_id) { comment.id }
+
+    context 'for a not owned comment' do
+      it 'raises not found' do
+        expect{
+          get(:show, :id => comment_id)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'for an owned comment' do
+      let(:comment) { Fabricate(:card_comment_with_parent, :user => user) }
+
+      before { get(:show, :id => comment_id) }
+
+      subject(:api_comment) { json_to_ostruct(response.body, :comment) }
+
+      its('keys.size') { should eq(10) }
+      its(:id) { should eq(comment.id) }
+      its(:content) { should eq(comment.content) }
+      its(:external_author_name) { should be_blank }
+      its(:updated_at) { should_not be_blank }
+      its(:user_id) { should eq(user.id) }
+      its(:project_id) { should eq(comment.project.id) }
+      its(:board_id) { should eq(comment.board.id) }
+      its(:parent_comment_id) { should eq(comment.parent_comment.id) }
+      its(:comment_ids) { should be_empty }
+      its(:card_id) { should eq(comment.commentable.id) }
+
+      context 'when comment is a parent comment' do
+        let(:comment_id) { comment.parent_comment.id }
+
+        its('keys.size') { should eq(10) }
+        its(:id) { should eq(comment.parent_comment.id) }
+        its(:card_id) { should be_blank }
+        its(:parent_comment_id) { should be_blank }
+        its(:comment_ids) { should include(comment.id) }
+      end
+    end
+  end
+
+  describe '#create' do
+    let(:comment_attrs) {
+      Fabricate.attributes_for(:comment_with_parent, :user => user) }
+    let(:comment) { user.comments.first }
+
+    before do
+      unless example.metadata[:skip_before]
+        post(:create, :comment => comment_attrs)
+      end
+    end
+
+    subject(:api_comment) { json_to_ostruct(response.body, :comment) }
+
+    its('keys.size') { should eq(10) }
+    its(:id) { should eq(comment.id) }
+    its(:content) { should eq(comment.content) }
+    its(:external_author_name) { should be_blank }
+    its(:updated_at) { should_not be_blank }
+    its(:user_id) { should eq(user.id) }
+    its(:project_id) { should eq(comment.project.id) }
+    its(:board_id) { should eq(comment.board.id) }
+    its(:parent_comment_id) { should eq(comment.parent_comment.id) }
+    its(:comment_ids) { should be_empty }
+    its(:card_id) { should be_blank }
+
+    context 'when commentable is wrong' do
+      let(:comment_attrs) {
+        Fabricate.attributes_for(:comment, :commentable_type => 'Wrong') }
+
+      subject(:api_comment) { json_to_ostruct(response.body) }
+
+      its(:errors) { should_not be_empty }
+    end
+
+    context 'when commentable is set' do
+      let(:board) { Fabricate(:branched_board, :user => user) }
+      let(:card) { Fabricate(
+        :card, :board => board, :project => board.project) }
+      let(:comment_attrs) { Fabricate.attributes_for(
+        :comment, :board => board, :project => board.project, :user => user,
+        :commentable_type => 'Card', :commentable_id => card.id) }
+
+      subject(:api_comment) { json_to_ostruct(response.body, :comment) }
+
+      its('keys.size') { should eq(10) }
+      its(:user_id) { should eq(user.id) }
+      its(:project_id) { should eq(comment.project.id) }
+      its(:board_id) { should eq(comment.board.id) }
+      its(:card_id) { should eq(card.id) }
+
+      context 'and commentable is not allowed', :skip_before do
+        let(:board) { Fabricate(:branched_board) }
+
+        it do
+          expect {
+            post(:create, :comment => comment_attrs)
+          }.to raise_error(ActiveRecord::RecordNotFound)
+        end
+
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:comment) { Fabricate(:comment) }
+    let(:comment_id) { comment.id }
+
+    before { delete(:destroy, :id => comment_id) }
+
+    its('response.status') { should eq(400) }
+    its('response.body') { should be_blank }
+
+    context 'for an available comment' do
+      let(:comment) { Fabricate(:comment, :user => user) }
+
+      its('response.status') { should eq(204) }
+      its('response.body') { should be_blank }
+    end
+  end
+end

--- a/spec/fabricators/comment_fabricator.rb
+++ b/spec/fabricators/comment_fabricator.rb
@@ -1,8 +1,9 @@
 Fabricator(:comment) do
+  content     { Faker::HTMLIpsum.fancy_string }
   user
-  project
-  board
-  content { Faker::HTMLIpsum.fancy_string }
+  project     { |attrs| Fabricate(:project, :user => attrs[:user]) }
+  board       { |attrs| Fabricate(
+    :board, :project => attrs[:project], :author => attrs[:user]) }
 end
 
 Fabricator(:comment_with_parent, :from => :comment) do

--- a/spec/fabricators/comment_fabricator.rb
+++ b/spec/fabricators/comment_fabricator.rb
@@ -9,11 +9,22 @@ Fabricator(:comment_with_parent, :from => :comment) do
   parent_comment { |attrs| Fabricate(:comment, :project => attrs[:project]) }
 end
 
-Fabricator(:card_comment, :from => :comment) do
+Fabricator(:board_comment, :from => :comment) do
   content     { Faker::HTMLIpsum.fancy_string }
   project     { |attrs| Fabricate(:project, :user => attrs[:user]) }
   board       { |attrs| Fabricate(
     :board, :project => attrs[:project], :author => attrs[:user]) }
+end
+
+Fabricator(:card_comment, :from => :board_comment) do
+  commentable { |attrs|
+    Fabricate('card/phrase', :project => attrs[:project],
+              :board => attrs[:board], :user => attrs[:user]) }
+end
+
+Fabricator(:card_comment_with_parent, :from => :board_comment) do
+  parent_comment { |attrs|
+    Fabricate(:comment, :project => attrs[:project], :board => attrs[:board]) }
   commentable { |attrs|
     Fabricate('card/phrase', :project => attrs[:project],
               :board => attrs[:board], :user => attrs[:user]) }

--- a/spec/fabricators/comment_fabricator.rb
+++ b/spec/fabricators/comment_fabricator.rb
@@ -1,12 +1,22 @@
 Fabricator(:comment) do
+  user
   project
   board
-  user
   content { Faker::HTMLIpsum.fancy_string }
 end
 
 Fabricator(:comment_with_parent, :from => :comment) do
   parent_comment { |attrs| Fabricate(:comment, :project => attrs[:project]) }
+end
+
+Fabricator(:card_comment, :from => :comment) do
+  content     { Faker::HTMLIpsum.fancy_string }
+  project     { |attrs| Fabricate(:project, :user => attrs[:user]) }
+  board       { |attrs| Fabricate(
+    :board, :project => attrs[:project], :author => attrs[:user]) }
+  commentable { |attrs|
+    Fabricate('card/phrase', :project => attrs[:project],
+              :board => attrs[:board], :user => attrs[:user]) }
 end
 
 Fabricator(:comment_from_angel_list, :class_name => Comment) do

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -19,6 +19,7 @@ describe Activity, :use_truncation do
 
     its(:user_name) { should eq(user.nicename) }
     its(:trackable_title) { should be_nil }
+    its(:comment_id) { should be_nil }
 
     context 'and title' do
       let(:project) { Fabricate(:project, :user => user) }

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -5,6 +5,7 @@ describe Card do
   it { should belong_to(:board) }
   it { should belong_to(:project) }
   it { should have_many(:activities).dependent('') }
+  it { should have_many(:comments).dependent(:destroy) }
 
   it { should validate_presence_of(:user) }
   it { should validate_presence_of(:board) }

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -46,9 +46,10 @@ describe Comment do
   end
 
   context '#activities', :use_truncation do
-    subject(:comment) { Fabricate(:card_comment) }
 
-    context 'first' do
+    context 'first on a card comment' do
+      let(:comment) { Fabricate(:card_comment) }
+
       subject { comment.commentable.activities.reload.first }
 
       its(:slug) { should eq('create-comment') }
@@ -56,11 +57,27 @@ describe Comment do
     end
 
     context 'first for a comment with parent comment' do
-      let(:with_parent) { Fabricate(:card_comment, :parent_comment => comment) }
-      subject { with_parent.commentable.activities.reload.first }
+      let(:comment) { Fabricate(:card_comment_with_parent) }
+      subject { comment.commentable.activities.reload.first }
 
       its(:slug) { should_not eq('create-comment') }
       its(:comment_id) { should be_blank }
+    end
+
+    context 'first for a board comment' do
+      let(:comment) { Fabricate(:board_comment) }
+      subject { comment.board.activities.reload.first }
+
+      its(:slug) { should eq('create-comment') }
+      its(:comment_id) { should eq(comment.id.to_s) }
+    end
+
+    context 'first for a project comment' do
+      let(:comment) { Fabricate(:board_comment, :board => nil) }
+      subject { comment.project.activities.reload.first }
+
+      its(:slug) { should eq('create-comment') }
+      its(:comment_id) { should eq(comment.id.to_s) }
     end
   end
 

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -6,6 +6,7 @@ describe Comment do
   it { should belong_to(:user) }
   it { should belong_to(:board) }
   it { should belong_to(:project) }
+  it { should belong_to(:commentable) }
 
   it { should validate_presence_of(:content) }
   it { should_not ensure_inclusion_of(
@@ -41,6 +42,25 @@ describe Comment do
         :external_type).in_array(Doers::Config.external_types) }
       its(:external?) { should be_true }
       its('author.nicename') { should eq(comment.external_author_name) }
+    end
+  end
+
+  context '#activities', :use_truncation do
+    subject(:comment) { Fabricate(:card_comment) }
+
+    context 'first' do
+      subject { comment.commentable.activities.reload.first }
+
+      its(:slug) { should eq('create-comment') }
+      its(:comment_id) { should eq(comment.id.to_s) }
+    end
+
+    context 'first for a comment with parent comment' do
+      let(:with_parent) { Fabricate(:card_comment, :parent_comment => comment) }
+      subject { with_parent.commentable.activities.reload.first }
+
+      its(:slug) { should_not eq('create-comment') }
+      its(:comment_id) { should be_blank }
     end
   end
 

--- a/spec/models/user/user_authorization_spec.rb
+++ b/spec/models/user/user_authorization_spec.rb
@@ -448,7 +448,7 @@ describe User do
         it { should be_true }
         it_behaves_like 'is writable'
 
-        context 'or a set of cards owned by the user' do
+        context 'or a set of such owned by the user' do
           let(:target) { user.activities }
 
           it { should be_true }

--- a/spec/routing/api/v1/comments_routing_spec.rb
+++ b/spec/routing/api/v1/comments_routing_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Api::V1::CommentsController do
+
+  describe 'routing' do
+
+    it 'for showing comments' do
+      get('/api/v1/comments').should route_to('api/v1/comments#index')
+    end
+
+    it 'for showing a comment' do
+      get('/api/v1/comments/1').should route_to(
+        'api/v1/comments#show', :id => '1')
+    end
+
+    it 'for creating a comment' do
+      post('/api/v1/comments').should route_to('api/v1/comments#create')
+    end
+
+    it 'for comment deletion' do
+      delete('/api/v1/comments/1').should route_to(
+        'api/v1/comments#destroy', :id => '1')
+    end
+
+  end
+end
+


### PR DESCRIPTION
Added comments API endpoint. This now serves mostly for cards.

Use card `activities` with `slug` **create-comment** and it's attribute `comment` to render comments inline with activities.

Use comment `comments` attribute to get child comments.

Currently we enabled comments just for cards: user, project, and board have comments relationship disabled on the API endpoint.

@stefangugurel please review and merge.
Thanks.
