### PR TITLE
Export boards

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'delayed_job_active_record'
 gem 'pg'
 gem 'oembedr'
 gem 'gutentag'
+gem 'zip', :require => false
 
 group :production do
   gem 'puma'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,7 @@ GEM
     xpath (2.0.0)
       nokogiri (~> 1.3)
     yard (0.8.7.1)
+    zip (2.0.2)
 
 PLATFORMS
   ruby
@@ -440,3 +441,4 @@ DEPENDENCIES
   uglifier
   vcr
   yard
+  zip

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -21,6 +21,8 @@ class PagesController < ApplicationController
 
   # Sends the export data to download
   def download
+    Delayed::Job.enqueue(ExportJob.new(current_account))
+    flash[:success] = _('Give us some time then check your email.')
     redirect_to export_pages_path
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -15,6 +15,15 @@ class PagesController < ApplicationController
     end
   end
 
+  # Export download page
+  def export
+  end
+
+  # Sends the export data to download
+  def download
+    redirect_to export_pages_path
+  end
+
   private
 
   # Allowed params for [User] objects

--- a/app/jobs/export_job.rb
+++ b/app/jobs/export_job.rb
@@ -1,0 +1,81 @@
+require 'erb'
+require 'zip'
+require 'pathname'
+
+# Data export job
+class ExportJob < Struct.new(:user)
+  attr_accessor :user_dir, :boards, :template_path, :template
+
+  def markdown_template
+    @template ||= ERB.new(template_path.read())
+  end
+
+  # Job starts here
+  def perform
+    @boards = []
+    @template_path =
+      Rails.root.join('app', 'views', 'jobs', 'export_board.text.erb')
+    @user_dir = Pathname.new(Dir.tmpdir).join(user.id.to_s)
+    @user_dir.unlink if @user_dir.exist?
+    @user_dir.mkpath
+
+    unless user.boards.empty?
+      prepare_boards
+      generate_json
+      generate_markdown
+      archive
+      send_email
+    end
+  end
+
+  def prepare_boards
+    user.boards.each do |board|
+      board_data = board.attributes.slice('id', 'title', 'description')
+      board_data['project'] = board.project.title if board.project
+
+      board_data['cards'] = []
+      board.cards.each do |card|
+        card_data = card.attributes.except(
+          'id', 'user_id', 'project_id', 'board_id', 'type')
+        card_data['type'] = card.type.demodulize
+        card_data['author'] = card.user.nicename
+
+        board_data['cards'].push(card_data)
+      end
+
+      boards.push(board_data)
+    end
+  end
+
+  def generate_json
+    boards.each do |board|
+      board_path = user_dir.join(board['id'].to_s + '.json')
+      File.write(board_path, board.to_json)
+    end
+  end
+
+  def generate_markdown
+    boards.each do |board|
+      board_path = user_dir.join(board['id'].to_s + '.markdown')
+      file_data = markdown_template.result(binding)
+      File.write(board_path, file_data)
+    end
+  end
+
+  def archive
+    file_path = user_dir + '.zip'
+    file_path.unlink if file_path.exist?
+
+    prefix = user_dir + '/'
+    files = Dir[File.join(user_dir, '**', '**')]
+    Zip::ZipFile.open(file_path, Zip::ZipFile::CREATE) do |zipfile|
+      files.each do |file|
+        zipfile.add(file.sub(prefix.to_s, ''), file)
+      end
+    end
+  end
+
+  def send_email
+  end
+
+end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -42,6 +42,7 @@ class UserMailer < ActionMailer::Base
     mail(:to => invitation.email, :subject => subject, :template_name => view)
   end
 
+  # Sends a notification about newly created membership user is part of
   def membership_notification(membership)
     @dashboard_url = root_url
     @user = membership.user
@@ -49,5 +50,13 @@ class UserMailer < ActionMailer::Base
     @target = membership.board || membership.project
     mail(:to => @user.email, :subject => _('%s added you to %s on %s.') % [
       @creator.nicename, @target.title, Doers::Config.app_name])
+  end
+
+  # Sends an email with exported data
+  def export_data(user, zip_path)
+    @user = user
+    attachments['doers_boards.zip'] = File.read(zip_path)
+    mail(:to => user.email, :subject => _('Your %s exported data.') % [
+      Doers::Config.app_name])
   end
 end

--- a/app/views/jobs/export_board.text.erb
+++ b/app/views/jobs/export_board.text.erb
@@ -1,0 +1,25 @@
+#### <%= board['project'] %>
+
+# <%= board['title'] %>
+
+### <%= board['description'] %>
+
+---
+
+## Cards
+
+<% board['cards'].each do |card| %>
+##### <%= card['question'] %>
+
+#### <%= card['title'] %>
+
+<%= card['content'] %>
+
+ * <%= card['type'] %> by <%= card['author'] %>
+<% card['data'].each do |attr_key, attr_val| %>
+ * <%= attr_key.humanize %>: <%= attr_val %>
+<% end %>
+
+---
+
+<% end %>

--- a/app/views/pages/export.html.haml
+++ b/app/views/pages/export.html.haml
@@ -5,15 +5,26 @@
 .content-wrap
 
   .page.half
-    %h1
-      = _('Your export options')
-    %p
-      = _('Below you can download your project boards data.')
-    %p
-      = _('You will get a package with boards content archived.')
-      = _('There will be two files for each board, one computer friendly (JSON), and the other one human friendly (Markdown).')
-    %p
-      %a{:href => download_pages_path}
-        %button.button
-          %span.icon.icon-arrow-down
-            = _('Start download')
+    - if @current_account.boards.count
+      %h1
+        = _('Your export options')
+      %p
+        = _('Below you can queue your project boards data for download.')
+      %p
+        = _('You will get an email with a package with boards content archived.')
+        = _('There will be two files for each board, one computer friendly (JSON), and the other one human friendly (Markdown).')
+      %p
+        %a{:href => download_pages_path}
+          %button.button
+            %span.icon.icon-arrow-down
+              = _('Email me boards data.')
+    - else
+      %h1
+        = _('No export options for you')
+      %p
+        = _('Export is not available for you since there are no boards you have created.')
+      %p
+        %a{:href => root_path}
+          %button.button
+            %span.icon.icon-arrow-prev
+              = _('Take me back to dashboard.')

--- a/app/views/pages/export.html.haml
+++ b/app/views/pages/export.html.haml
@@ -1,0 +1,19 @@
+.header
+  .header-root
+    = _('Data Export')
+
+.content-wrap
+
+  .page.half
+    %h1
+      = _('Your export options')
+    %p
+      = _('Below you can download your project boards data.')
+    %p
+      = _('You will get a package with boards content archived.')
+      = _('There will be two files for each board, one computer friendly (JSON), and the other one human friendly (Markdown).')
+    %p
+      %a{:href => download_pages_path}
+        %button.button
+          %span.icon.icon-arrow-down
+            = _('Start download')

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -16,7 +16,7 @@
           = f.text_field :name, :required => true
         - if current_account.admin?
           .field.checkbox
-            = f.check_box :confirmed?
+            = f.check_box :confirmed
             = f.label :confirmed, _('Allow Beta')
         .actions
           = f.submit _('Save'), :class => 'button'

--- a/app/views/user_mailer/export_data.text.haml
+++ b/app/views/user_mailer/export_data.text.haml
@@ -1,0 +1,12 @@
+= _('Hello %s.') % @user.nicename
+\
+\
+= _('Your boards were exported successfully.')
+\
+= _('As requested, we are sending you an archive with your data as JSON and Markdown.')
+\
+= _('Thank you for the patience.')
+\
+\
+= _('Your %s team.') % Doers::Config.app_name
+= Doers::Config.app_id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,8 @@ Doers::Application.routes.draw do
     get :dashboard
     get :waiting
     patch :waiting
+    get :export
+    get :download
   end
 
   namespace :api, :constraints => {:format => :json} do

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -52,4 +52,22 @@ describe PagesController do
     end
   end
 
+  describe '#export' do
+    before do
+      controller.stub(:current_account) { user }
+      get(:export)
+    end
+
+    it { should render_template(:export) }
+  end
+
+  describe '#download' do
+    before do
+      controller.stub(:current_account) { user }
+      get(:download)
+    end
+
+    it { should redirect_to(export_pages_path) }
+  end
+
 end

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -64,6 +64,8 @@ describe PagesController do
   describe '#download' do
     before do
       controller.stub(:current_account) { user }
+      ImportJob.stub_chain(:new, :perform)
+      Delayed::Job.should_receive(:enqueue).and_call_original
       get(:download)
     end
 

--- a/spec/jobs/export_job_spec.rb
+++ b/spec/jobs/export_job_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+describe ExportJob do
+  let(:board) { Fabricate(:board_with_cards) }
+  let(:user) { board.user }
+  let(:job) { ExportJob.new(user) }
+
+  subject{ job }
+
+  context '#perform' do
+    context 'when user has no boards' do
+      let(:user) { Fabricate(:user) }
+
+      before do
+        job.perform
+      end
+
+      its('user_dir.to_s') { should match(user.id.to_s) }
+      its(:boards) { should be_empty }
+      its(:template) { should be_nil }
+      its(:template_path) { should eq(
+        Rails.root.join('app', 'views', 'jobs', 'export_board.text.erb')) }
+    end
+
+    context 'when user has boards' do
+      before do
+        job.should_receive(:prepare_boards)
+        job.should_receive(:generate_json)
+        job.should_receive(:generate_markdown)
+        job.should_receive(:archive)
+        job.should_receive(:send_email)
+        job.perform
+      end
+
+      its(:boards) { should be_empty }
+    end
+  end
+
+  context '#prepare_boards' do
+    before do
+      job.should_receive(:prepare_boards).and_call_original
+      job.should_receive(:generate_json)
+      job.should_receive(:generate_markdown)
+      job.should_receive(:archive)
+      job.should_receive(:send_email)
+      job.perform
+    end
+
+    its('boards.count') { should eq(user.boards.count) }
+
+    context '#boards.first' do
+      subject(:first_board){ job.boards.first }
+
+      its('keys.sort') { should eq(%w(cards description id project title)) }
+
+      context 'cards' do
+        subject{ first_board['cards'] }
+
+        it { should_not be_empty }
+      end
+
+      context 'cards.first' do
+        subject{ first_board['cards'].first }
+
+        its('keys.sort') { should eq(%w(author content created_at data help
+          parent_card_id position question style title type updated_at)) }
+      end
+    end
+
+  end
+
+  context '#generate_json' do
+    before do
+      job.should_receive(:generate_json).and_call_original
+      job.should_receive(:generate_markdown)
+      job.should_receive(:archive)
+      job.should_receive(:send_email)
+      job.perform
+    end
+
+    it 'generates json files' do
+      job.boards.each do |b|
+        json = File.read(job.user_dir.join(b['id'].to_s + '.json'))
+        json.should eq(b.to_json)
+      end
+    end
+  end
+
+  context '#generate_markdown' do
+    before do
+      job.should_receive(:generate_markdown).and_call_original
+      job.should_receive(:archive)
+      job.should_receive(:send_email)
+      job.perform
+    end
+
+    it 'generates markdown files' do
+      job.boards.each do |b|
+        mkdn = File.read(job.user_dir.join(b['id'].to_s + '.markdown'))
+        mkdn.should include(b['title'])
+        mkdn.should include(b['project'])
+        mkdn.should include(b['description'])
+        b['cards'].each do |c|
+          mkdn.should include(c['title'])
+          mkdn.should include(c['question'])
+          mkdn.should include(c['content'].to_s)
+          mkdn.should include(c['type'])
+          c['data'].each do |k, v|
+            mkdn.should include(k.humanize + ': ' + v)
+          end
+        end
+      end
+    end
+  end
+
+  context '#archive' do
+    before do
+      job.should_receive(:archive).and_call_original
+      job.should_receive(:send_email)
+      job.perform
+    end
+
+    subject{ Pathname.new(job.user_dir + '.zip') }
+
+    it { should exist }
+    its(:size) { should_not eq(0) }
+  end
+
+  context '#send_email' do
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -90,4 +90,21 @@ describe UserMailer do
       its('body.encoded') { should match(invitation.invitable.title) }
     end
   end
+
+  context '#export_data' do
+    let(:user) { Fabricate(:user) }
+    let(:zip_path) { File.expand_path(user.id.to_s + '.zip', Dir.tmpdir) }
+
+    before do
+      File.write(zip_path, rand(100))
+      UserMailer.export_data(user, zip_path).deliver
+    end
+    after { File.unlink(zip_path) }
+
+    it_should_behave_like 'an email from us'
+    its('body.encoded') { should match(user.nicename) }
+    its('attachments') { should have(1).attachment }
+    its('attachments.first.filename') { should eq('doers_boards.zip') }
+    its(:to) { should include(user.email) }
+  end
 end

--- a/spec/routing/pages_routing_spec.rb
+++ b/spec/routing/pages_routing_spec.rb
@@ -16,6 +16,14 @@ describe PagesController do
       patch('/waiting').should route_to('pages#waiting')
     end
 
+    it 'for export page' do
+      get('/export').should route_to('pages#export')
+    end
+
+    it 'for download page' do
+      get('/download').should route_to('pages#download')
+    end
+
   end
 end
 


### PR DESCRIPTION
Boards can be exported now.

Basically it will prepare an archive with all the data from user boards and will email it to you in json and markdown files.

@stefangugurel please review and merge this.
Thanks.

TODO: We might gonna need mixpanel hooked into this.
